### PR TITLE
Add option to return proportion

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ function createPlaceholder(content, placeholder, ext, blur, callback){
 function createResponsiveImages(content, sizes, ext, files, emitFile, addProportion, callback){
   var count = 0;
   var images = [];
+  var imgset = files.map(function(file, i){ return file + ' ' + sizes[i] + ' '; }).join(',');
 
   sizes.map(function(size, i){
     size = parseInt(size);
@@ -45,20 +46,14 @@ function createResponsiveImages(content, sizes, ext, files, emitFile, addProport
 
         count++;
         if (count >= files.length) {
-          var imgset = files.map(function(file, i){
-              var filenames = file + ' ' + sizes[i] + ' ';
-              if (addProportion) {
-                  return JSON.stringify({
-                      srcset: filenames,
-                      proportion: originalSize.height / originalSize.width
-                  })
-              }
-              return filenames;
-          }).join(',');
+        
           if (!addProportion) {
-              imgset = "\"" + imgset + "\"";
+              callback(null, "module.exports = \""+imgset+"\"");
+          } else {
+              var proportion = originalSize.height / originalSize.width;
+              callback(null, "module.exports = "+ JSON.stringify({srcset: imgset, proportion: proportion}));
           }
-          callback(null, "module.exports = "+imgset+"");
+
         }
     });
   });


### PR DESCRIPTION
Something I added for my own use that others might also find useful - if you pass `proportion=1` into the loader it'll return an object like so:

`{srcset:'file.jpg 500w', proportion:0.6}`

This is useful to pre-allocate space on a page before the image has downloaded, and minimise DOM redraws.