### PR TITLE
ImageMagick external dependency removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "datauri": "^0.7.1",
     "debug": "^2.2.0",
     "file-loader": "^0.8.4",
+    "image-size": "^0.3.5",
     "loader-utils": "^0.2.6"
   },
   "peerDependencies": {
-    "gm": "*",
+    "lwip": "*",
     "file-loader": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi there,

I think it could be better to replace the external dependency to ImageMagick with its npm-able brother lwip (see http://eyalarubas.com/image-processing-nodejs.html and its repo https://github.com/EyalAr/lwip).

The main avantage is that you only need to `npm install` to get all your dependencies, but you have to be able to compile lwip’s native code. (https://github.com/EyalAr/lwip#installation and https://github.com/nodejs/node-gyp#installation)
